### PR TITLE
Fix github api stub with new key value pairs for friendship creation

### DIFF
--- a/spec/features/user/user_can_add_friends_spec.rb
+++ b/spec/features/user/user_can_add_friends_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 describe 'User' do
   it 'can see an Add Link next to a github user on the dashboard only if the github user is in the db' do
-    stub_github_users_api_call
+    stub_github_followers_api_call
+    stub_github_following_api_call
 
     user = create(:user)
     follower = create(:user, github_id: 36523304)
@@ -21,7 +22,8 @@ describe 'User' do
     end
   end
   it 'can add a new friend by clicking on the Add Friend link' do
-    stub_github_users_api_call
+    stub_github_followers_api_call
+    stub_github_following_api_call
 
     user = create(:user)
     follower = create(:user, github_id: 36523304, first_name: "French", last_name: "Bulldog")
@@ -48,7 +50,8 @@ describe 'User' do
     end
   end
   it 'cannot add a new friend if the friend is not in the database' do
-    stub_github_users_api_call
+    stub_github_followers_api_call
+    stub_github_following_api_call
 
     user = create(:user)
 

--- a/spec/features/user/user_goes_to_dashboard_and_connect_to_github_spec.rb
+++ b/spec/features/user/user_goes_to_dashboard_and_connect_to_github_spec.rb
@@ -8,7 +8,7 @@ feature'User' do
     stub_github_following_api_call
 
     # As a user
-    user = create(:user)
+    user = create(:user, github_id: 36523304)
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
     # When I visit /dashboard
     visit dashboard_path

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,5 +75,5 @@ end
 
 def stub_omniauth
   OmniAuth.config.test_mode = true
-  OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new( {"provider" => "github","credentials" => {"token" => "123456"}})
+  OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new( {"provider" => "github","credentials" => {"token" => "123456"}, "extra" => {"raw_info" => {"id" => 36523304}}})
 end


### PR DESCRIPTION
- [ ] Wrote Tests
- [ ] Implemented
- [ ] Reviewed


# Necessary checkmarks:
- [X] All Tests are Passing
- [X] The code will run locally

## Type of change
- [ ] New feature
- [X] Bug Fix

# Implements/Fixes:
## Description of Changes - Had to add additional key-value pairs to API OAuth stub for friendship feature capability 

closes #

# Check the correct boxes
- [X] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

# Testing Changes
- [X] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

# Checklist:

- [X] My code has no unused/commented out code
- [X] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have fully tested my code

# Please include a link to a gif of how you feel about this branch:
